### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next-auth": "^4.24.13",
     "nodemailer": "^7.0.13",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "sanitize-filename": "^1.6.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/lib/email/fake-email-service.ts
+++ b/src/lib/email/fake-email-service.ts
@@ -1,6 +1,7 @@
 import { EmailService } from "./types";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
+import sanitize from "sanitize-filename";
 
 export class FakeEmailService implements EmailService {
   async sendEmail(to: string, subject: string, htmlBody: string): Promise<void> {
@@ -13,7 +14,8 @@ export class FakeEmailService implements EmailService {
     try {
       const dir = path.join(process.cwd(), "email");
       await mkdir(dir, { recursive: true });
-      const filename = `${Date.now()}-${to.replace(/[^a-zA-Z0-9]/g, "_")}.txt`;
+      const safeTo = sanitize(to) || "recipient";
+      const filename = `${Date.now()}-${safeTo.replace(/[^a-zA-Z0-9]/g, "_")}.txt`;
       await writeFile(path.join(dir, filename), text, "utf-8");
     } catch (err) {
       console.error("Failed to write fake email to disk:", err);


### PR DESCRIPTION
Potential fix for [https://github.com/neilhewitt/Simionic-G1000-CustomProfiles-Next/security/code-scanning/1](https://github.com/neilhewitt/Simionic-G1000-CustomProfiles-Next/security/code-scanning/1)

In general, to fix uncontrolled data in path expressions when you only need a simple filename, you should sanitize the user-controlled portion with a robust filename sanitizer (or an allow list) so that the resultant string cannot contain path separators, `..` segments, or other hazardous characters, and then join it with a fixed directory. This makes it impossible for the user to escape the intended folder via crafted input.

For this code, the best low-impact fix is to replace the ad‑hoc regex-based sanitization with the `sanitize-filename` npm package, which is purpose-built for this scenario and widely used. We will:

- Import `sanitize-filename` at the top of `src/lib/email/fake-email-service.ts`.
- Use it to sanitize the `to` value into a safe filename component.
- Preserve the existing behavior (alphanumeric-ish base, `.txt` suffix, same directory) as much as possible.

Concretely, in `src/lib/email/fake-email-service.ts`:

1. Add `import sanitize from "sanitize-filename";`.
2. In `sendEmail`, before building `filename`, derive `const safeTo = sanitize(to) || "recipient";` to avoid an empty string if the email address has no allowable characters.
3. Change the filename construction from using `.replace(/[^a-zA-Z0-9]/g, "_")` to using `safeTo.replace(/[^a-zA-Z0-9]/g, "_")` (or simply use `safeTo` directly if you want to rely solely on the library). This keeps the observable filename format similar while ensuring a dedicated sanitizer has already stripped dangerous content.
4. Keep `path.join(dir, filename)` the same, since now `filename` is guaranteed to be safe.

No changes are needed in `src/app/api/auth/convert/request/route.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
